### PR TITLE
Bugfix - Loop Element Remove

### DIFF
--- a/windows-exploit-suggester.py
+++ b/windows-exploit-suggester.py
@@ -651,6 +651,7 @@ def run(database):
   ALERT("comparing the %s hotfix(es) against the %s potential bulletins(s) with a database of %s known exploits" % (len(hotfixes), len(bulletinids), getexploit()))
 
   # start removing the vulns because of hotfixes
+  actual = []
   for row in potential:
 
     # ms bulletin
@@ -685,8 +686,13 @@ def run(database):
             ALERT("    due to presence of KB%s (Component KB) removing%s bulletin(s)" % (componentkb, linkedmsstr))
 
         bulletinids = bulletinids.difference(linkedms)
-        potential.remove(row)
+        # potential.remove(row)
+     
+      else:
+        # Add to the actually open issues
+        actual.append(row)
 
+  potential = actual
   ALERT("there are now %s remaining vulns" % len(bulletinids))
 
   # search local exploits only


### PR DESCRIPTION
Removing the element during the loop causes the loop to skip the next element 
> this is a relevant bug

1 2 3 4 5 (6) (7) (8) (9)
--------^
removing 5 during the loop shifts the remaining elements to the left 
1 2 3 4 6 7 (8) (9)
-----------^

but the pointer in the python loop moves to the next element when it returns to 
line 655: "for row in potential:"

This skips elements during the potential vulnerability loop leading to false positives.