### PR TITLE
Fix for french systeminfo version

### DIFF
--- a/windows-exploit-suggester.py
+++ b/windows-exploit-suggester.py
@@ -980,7 +980,12 @@ def getname(ostext):
     for needle in osnamearray:
       if needle[0] + " " in ostext.lower():
         osname = needle[1]
-
+  # Small patch for French systeminfo where non-breaking space is insert between "Windows\u00A07 Enterprise"
+  if not osname:
+    for needle in osnamearray:
+      if needle[0] + " " in ostext.lower().replace(u"\u00A0", " "):
+	osname = needle[1]
+	
   return osname
 
 


### PR DESCRIPTION
Remove non-breaking space from Windows version for French systeminfo files.