### PR TITLE
Issue#34 Fix parsing OS name for Windows Server 2016

### DIFF
--- a/windows-exploit-suggester.py
+++ b/windows-exploit-suggester.py
@@ -411,7 +411,8 @@ def main():
       except IOError as e:
         ALERT("no such file or directory '%s'. ensure you have the correct database file passed in --database/-d" % ARGS.database, ALERT.BAD)
         exit(1)
-      sh = wb.sheet_by_name('Export Bulletin Search Spreadsh')
+      #sh = wb.sheet_by_name('Export Bulletin Search Spreadsh')
+      sh = wb.sheet_by_index(0)
 
       # read the spreadsheet into a temp file
       f = NamedTemporaryFile(mode='wb')

--- a/windows-exploit-suggester.py
+++ b/windows-exploit-suggester.py
@@ -585,17 +585,45 @@ def run(database):
 
   # now process the hotfixes argument input
   if ARGS.hotfixes:
-  
-    # open the file
-    try:
-      cmdfile = open(ARGS.hotfixes, "r")
 
-    except IOError as e:
-      ALERT("could not read from input file specified: %s" % ARGS.hotfixes, ALERT.BAD)
+    encodings = ['utf-8', 'utf-16', 'utf-16-le', 'utf-16-be', 'iso-8859-2']
+
+    detected_encoding =  detect_encoding(ARGS.systeminfo)
+
+    # insert detected encoding to the front of the list
+    if detected_encoding: 
+      if ARGS.verbose: ALERT("detected encoding of file as '%s'" % detected_encoding)
+      encodings.insert(0, detected_encoding)
+
+    cmdfile = None
+    hotfixesfile = None
+    
+    # now loop through all encodings, with the detected one first (if it was possible)
+    for encoding in encodings:
+
+      if ARGS.verbose: ALERT("  attempting to read with '%s' encoding" % encoding)          
+
+      # if we can read the file, and read the command output, we are done with the loop
+      try: 
+        cmdfile = io.open(ARGS.hotfixes, "r", encoding=encoding) # throws UnicodeDecodeError      
+        hotfixesfile = cmdfile.readlines() # throws UnicodeError
+        break
+
+      except (UnicodeError, UnicodeDecodeError) as e:
+        if ARGS.verbose: ALERT("could not read file using '%s' encoding: %s" % (encoding, e), ALERT.BAD)
+  
+      # file might not exist
+      except:
+        ALERT("could not read from input file specified: %s" % ARGS.hotfixes, ALERT.BAD)
+        exit(1)  
+
+    # general catchall if somehow it was able to keep processing
+    if not cmdfile or not hotfixesfile:
+      ALERT("could not read from input file, or could not detect encoding", ALERT.BAD)
       exit(1)
 
-    ALERT("reading from the hotfixes input file")
-    hotfixesfile = cmdfile.readlines()
+    # file read successfully
+    ALERT("hotfixes input file read successfully (%s)" % encoding, ALERT.GOOD)
     
     # loop through hotfixes file input
     for haystack in hotfixesfile:

--- a/windows-exploit-suggester.py
+++ b/windows-exploit-suggester.py
@@ -684,7 +684,7 @@ def run(database):
   ALERT("comparing the %s hotfix(es) against the %s potential bulletins(s) with a database of %s known exploits" % (len(hotfixes), len(bulletinids), getexploit()))
 
   # start removing the vulns because of hotfixes
-  for row in potential:
+  for row in list(potential):
 
     # ms bulletin
     bulletinid=row[1]
@@ -725,7 +725,7 @@ def run(database):
   # search local exploits only
   if ARGS.local:
     ALERT("searching for local exploits only")
-    for row in potential:
+    for row in list(potential):
       bulletinid = row[1]
       impact = row[4]
 
@@ -742,7 +742,7 @@ def run(database):
   # search remote exploits only
   if ARGS.remote:
     ALERT("searching for remote exploits only")
-    for row in potential:
+    for row in list(potential):
       bulletinid = row[1]
       impact = row[4]
 

--- a/windows-exploit-suggester.py
+++ b/windows-exploit-suggester.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
 #
 # Windows Exploit Suggester
-# revision 3.2, 2016-07-15
+# revision 3.3, 2017-02-13
 #
 # author: Sam Bertram, Gotham Digital Science
 # contact: labs@gdssecurity.com,sbertram@gdssecurity.com,sammbertram@gmail.com
@@ -164,8 +165,10 @@
 #  Windows Server 2008 R2 for Itanium-based Systems Service Pack 1
 #
 # CHANGE LOG
-# v32 2016-07-15
-# - 
+# v33 2017-02-13
+# - added links to exploits and resources for each bulletins. can be ignored with the -q/--quiet flag
+# - hard coded ms11-011 to ignore false positives
+# - added additional resources
 #
 # v31 2016-02-10
 # - changed bulletin url, microsoft 404'd it
@@ -351,6 +354,7 @@ parser.add_argument("-p", "--patches", help="used to determine specific patches 
 parser.add_argument("-o", "--ostext", help="a loose text representation of the windows OS (ex: \"windows xp home edition sp2\")")
 parser.add_argument("-s", "--sub", help="generate output using linked/sub bulletins. WARNING: SLOW!", action="store_true")
 parser.add_argument("-2", "--duplicates", help="allow duplicate ms bulletin output within the results. this will produce a lot of output, but is useful when determining linked ms bulletins", action="store_true")
+parser.add_argument("-q", "--quiet", help="don't show exploit information. shorter output", action="store_true")
 # hotfixes
 # used to parse "wmic qfe list full" input, and to solve the 'File 1' errors
 parser.add_argument("-H", "--hotfixes", help="a loose list of hotfixes to be added, for use with the following command: 'wmic qfe list full'")
@@ -682,7 +686,7 @@ def run(database):
     exit(1)
 
   ALERT("comparing the %s hotfix(es) against the %s potential bulletins(s) with a database of %s known exploits" % (len(hotfixes), len(bulletinids), getexploit()))
-
+  
   # start removing the vulns because of hotfixes
   for row in list(potential):
 
@@ -766,8 +770,22 @@ def run(database):
   ALERT("")
 
   # vulns, the dictionary of the bulletins based off of the potential bulletins
+  # also, a good opportunity to remove false-positives due to the
+  # differences in the technet post and bulletin
   for row in potential:
     id = row[1]
+
+    # start removing vulns because of false-positives
+    # Manual override for MS11-011 to reduce false positives. The article was updated, but the bulletin database wasn't (https://technet.microsoft.com/en-us/library/security/ms11-011.aspx)
+    # V1.2 (March 18, 2011): Added Windows 7 for 32-bit Systems Service Pack 1, Windows 7 for x64-based Systems Service Pack 1, Windows Server 2008 R2 for x64-based Systems Service Pack 1, and Windows Server 2008 R2 for Itanium-based Systems Service Pack 1 to Non-Affected Software. This is an informational change only. There were no changes to the security update files or detection logic.
+    if id == 'MS11-011':
+        ms11_011 = ['Windows 7 for 32-bit Systems Service Pack 1', 'Windows 7 for x64-based Systems Service Pack 1', 'Windows Server 2008 R2 for x64-based Systems Service Pack 1','Windows Server 2008 R2 for Itanium-based Systems Service Pack 1']
+        for not_affected in ms11_011:
+            compare_version = getversion(getname(not_affected),getrelease(not_affected),getservicepack(not_affected),getarchitecture(not_affected))
+            if version == compare_version:
+                if ARGS.verbose: ALERT("Ignoring MS11-011 false positive due to it not affecting '%s'" % compare_version)
+                id = False
+        
     for bulletinid in bulletinids:
       if bulletinid == id:
         title = row[5]
@@ -782,7 +800,7 @@ def run(database):
   # msids, the actual data for all of the relevant msids (the row from the CSV)
   alerted = set()
   msids = sorted(vulns, reverse=True)
-
+  
   # loop through the bulletinids which is the set of the actual bulletins that are to
   # be alerted
   for msid in msids:
@@ -790,9 +808,9 @@ def run(database):
     ## don't alert twice, no matter the case
     if msid not in alerted: 
 
-      # get the exploitability alert rating
-      exploit = getexploit(msid)
-
+      # get the msid, exploitability alert rating, and resources
+      m,exploit,resources = getexploit(msid)
+      
       # only display the message, if the exploit flag isn't used
       # or if it is used, and the alert level is MSF or EXP
       if ARGS.audit or (exploit == ALERT.MSF or exploit == ALERT.EXP):
@@ -801,6 +819,11 @@ def run(database):
         if exploit: alert = exploit
       
         ALERT("%s: %s (%s) - %s" % (msid, vulns[msid][0], vulns[msid][1], vulns[msid][2]), alert)
+        if resources and not ARGS.quiet:
+            for resource in resources:
+                ALERT("  %s" % resource)
+            ALERT("")
+                
         alerted.add(msid)
 
         # only attempt to display linked/sub msids based on cli arguments
@@ -810,7 +833,7 @@ def run(database):
           linked = set(getlinkedms([msid], csv.reader(StringIO.StringIO(database))))
           linked = linked.intersection(msids)
           
-	  # loop through the linked msids, and only display those that qualify and
+	      # loop through the linked msids, and only display those that qualify and
           # those that have not been alerted yet
           for lmsid in sorted(linked, reverse=True):
             if lmsid in msids and lmsid not in alerted:
@@ -819,6 +842,7 @@ def run(database):
               if ARGS.audit or (lexploit == ALERT.MSF or lexploit == ALERT.EXP):
                 if lexploit: lalert = lexploit
                 ALERT("|_%s: %s (%s) - %s" % (lmsid, vulns[lmsid][0], vulns[lmsid][1], vulns[lmsid][2]), lalert)
+                
 		# only allow duplicate events to be displayed when command-line args passed
 		if not ARGS.duplicates: alerted.add(lmsid)
 
@@ -1231,102 +1255,149 @@ def getexploit(msid = 0):
 
 # no ms number yet?
 #MS??-???,http://www.exploit-db.com/exploits/30014/,P,??2914486
+  # bulletin, type, details
   exploits = [
-    ['MS16-075', ALERT.MSF], # CVE 2016-3225
-                             # https://github.com/Kevin-Robertson/Tater
-                             # Windows: Local WebDAV NTLM Reflection Elevation of Privilege	, https://bugs.chromium.org/p/project-zero/issues/detail?id=222&redir=1
-                             # Hot Potato - Windows Privilege Escalation, https://foxglovesecurity.com/2016/01/16/hot-potato/
-    ['MS16-074', ALERT.EXP], # CVE 2016-3216
-                             # https://www.exploit-db.com/exploits/39990/, Windows - gdi32.dll Multiple DIB-Related EMF Record Handlers Heap-Based Out-of-Bounds Reads/Memory Disclosure (MS16-074), PoC
-                             # CVE 2016-3220
-                             # https://www.exploit-db.com/exploits/39991/, Windows Kernel - ATMFD.DLL NamedEscape 0x250C Pool Corruption (MS16-074), PoC
-    ['MS16-063', ALERT.EXP], # CVE 2016-0199
-                             # https://www.exploit-db.com/exploits/39994/, Internet Explorer 11 - Garbage Collector Attribute Type Confusion (MS16-063), PoC
-    ['MS16-042', ALERT.EXP], # CVE 2016-0122
-                             # https://www.exploit-db.com/exploits/39694/, Microsoft Office Excel Out-of-Bounds Read Remote Code Execution (MS16-042), PoC
-    ['MS16-059', ALERT.EXP], # CVE 2016-0185
-                             # https://www.exploit-db.com/exploits/39805/, Microsoft Windows Media Center - .MCL File Processing Remote Code Execution (MS16-059), PoC
-    ['MS16-032', ALERT.EXP], # CVE 2016-0099
-                             # https://www.exploit-db.com/exploits/40107/, MS16-032 Secondary Logon Handle Privilege Escalation, MSF
-                             # https://www.exploit-db.com/exploits/39574/, Microsoft Windows 8.1/10 - Secondary Logon Standard Handles Missing Sanitization Privilege Escalation (MS16-032), PoC
-                             # https://www.exploit-db.com/exploits/39719/, Microsoft Windows 7-10 & Server 2008-2012 (x32/x64) - Local Privilege Escalation (MS16-032) (PowerShell), PoC
-                             # https://www.exploit-db.com/exploits/39809/, Microsoft Windows 7-10 & Server 2008-2012 (x32/x64) - Local Privilege Escalation (MS16-032) (C#)
-    ['MS16-016', ALERT.MSF], # CVE 2016-0051
-                             # https://www.exploit-db.com/exploits/40085/, MS16-016 mrxdav.sys WebDav Local Privilege Escalation, MSF
-                             # https://www.exploit-db.com/exploits/39788/, Microsoft Windows 7 - WebDAV Privilege Escalation Exploit (MS16-016) (2), PoC
-                             # https://www.exploit-db.com/exploits/39432/, Microsoft Windows 7 SP1 x86 - WebDAV Privilege Escalation (MS16-016) (1), PoC
-    ['MS16-014', ALERT.EXP], # CVE 2016-0400
-                             # Windows 7 SP1 x86 - Privilege Escalation (MS16-014), https://www.exploit-db.com/exploits/40039/, PoC
-    ['MS16-007', ALERT.EXP],  # CVE 2016-0015
-                             # https://www.exploit-db.com/exploits/39232/, Microsoft Windows devenum.dll!DeviceMoniker::Load() - Heap Corruption Buffer Underflow (MS16-007), PoC
-                             # CVE 2016-0016
-                             # https://www.exploit-db.com/exploits/39233/, Microsoft Office / COM Object DLL Planting with WMALFXGFXDSP.dll (MS-16-007), PoC
-    ['MS15-134', ALERT.EXP], # CVE 2015-6131
-                             # https://www.exploit-db.com/exploits/38911/, Microsoft Windows Media Center Library Parsing RCE Vulnerability aka "self-executing" MCL File, PoC
-                             # https://www.exploit-db.com/exploits/38912/, Microsoft Windows Media Center Link File Incorrectly Resolved Reference, PoC
-    ['MS15-132', ALERT.EXP], # CVE 2015-6132
-                             # https://www.exploit-db.com/exploits/38968/, Microsoft Office / COM Object DLL Planting with comsvcs.dll Delay Load of mqrt.dll (MS15-132), PoC
-                             # CVE 2015-6128
-                             # https://www.exploit-db.com/exploits/38918/, Microsoft Office / COM Object els.dll DLL Planting (MS15-134), PoC
-    ['MS15-112', ALERT.EXP], # CVE 2015-6086
-                             # https://www.exploit-db.com/exploits/39698/, Internet Explorer 9/10/11 - CDOMStringDataList::InitFromString Out-of-Bounds Read (MS15-112), 
-    ['MS15-111', ALERT.EXP], # CVE 2015-2553
-                             # https://www.exploit-db.com/exploits/38474/, Windows 10 Sandboxed Mount Reparse Point Creation Mitigation Bypass (MS15-111), PoC
-    ['MS15-102', ALERT.EXP], # CVE 2015-2524
-                             # https://www.exploit-db.com/exploits/38202/, Windows CreateObjectTask SettingsSyncDiagnostics Privilege Escalation, PoC
-                             # CVE 2015-2525
-                             # https://www.exploit-db.com/exploits/38200/, Windows Task Scheduler DeleteExpiredTaskAfter File Deletion Privilege Escalation, PoC
-                             # CVE 2015-2528
-                             # https://www.exploit-db.com/exploits/38201/, Windows CreateObjectTask TileUserBroker Privilege Escalation, PoC
-    ['MS15-100', ALERT.MSF], # CVE 2015-2509
-                             # https://www.exploit-db.com/exploits/38195/, MS15-100 Microsoft Windows Media Center MCL Vulnerability, MSF
-                             # https://www.exploit-db.com/exploits/38151/, Windows Media Center - Command Execution (MS15-100), PoC
-    ['MS15-097', ALERT.EXP], # CVE 2015-2508
-                             # https://www.exploit-db.com/exploits/38198/, Windows 10 Build 10130 - User Mode Font Driver Thread Permissions Privilege Escalation, PoC
-                             # CVE 2015-2527
-                             # https://www.exploit-db.com/exploits/38199/, Windows NtUserGetClipboardAccessToken Token Leak, PoC
-    ['MS15-078', ALERT.MSF], # CVE 2015-2426, CVE 2015-2433
-                             # https://www.exploit-db.com/exploits/38222/, MS15-078 Microsoft Windows Font Driver Buffer Overflow
-    ['MS15-052', ALERT.EXP], # CVE 2015-1674
-                             # https://www.exploit-db.com/exploits/37052/, Windows - CNG.SYS Kernel Security Feature Bypass PoC (MS15-052), PoC
-    ['MS15-051', ALERT.MSF], # CVE 2015-1701
-                             # https://github.com/hfiref0x/CVE-2015-1701, Win32k Elevation of Privilege Vulnerability, PoC
-                             # https://www.exploit-db.com/exploits/37367/, Windows ClientCopyImage Win32k Exploit, MSF
-    ['MS15-022', ALERT.EXP], # CVE 2015-0097
-                             # https://www.exploit-db.com/exploits/37657/, Microsoft Word Local Machine Zone Remote Code Execution Vulnerability, PoC
-                             # https://github.com/offensive-security/exploit-database-bin-sploits/raw/master/sploits/37657.zip
-    ['MS15-010', ALERT.EXP], # CVE 2015-0057
-                             # https://www.exploit-db.com/exploits/39035/, Microsoft Windows 8.1 - win32k Local Privilege Escalation (MS15-010), PoC
-                             # https://www.exploit-db.com/exploits/37098/, Microsoft Windows - Local Privilege Escalation (MS15-010), PoC
-                             # https://www.exploit-db.com/exploits/39035/, Microsoft Windows win32k Local Privilege Escalation (MS15-010), PoC
-    ['MS15-001', ALERT.EXP], # CVE 2015-0002
-                             # http://www.exploit-db.com/exploits/35661/, Windows 8.1 (32/64 bit) - Privilege Escalation (ahcache.sys/NtApphelpCacheControl), PoC
-    ['MS14-070', ALERT.EXP], # CVE 2014 4076
-                             # http://www.exploit-db.com/exploits/35936/, Microsoft Windows Server 2003 SP2 - Privilege Escalation, PoC
-    ['MS14-068', ALERT.EXP], # CVE 2014-6324
-                             # http://www.exploit-db.com/exploits/35474/, Windows Kerberos - Elevation of Privilege (MS14-068), PoC
-    ['MS14-064', ALERT.MSF], # CVE 2014-6332
-                             # https://www.exploit-db.com/exploits/37800/,  Microsoft Windows HTA (HTML Application) - Remote Code Execution (MS14-064), PoC
-                             # http://www.exploit-db.com/exploits/35308/, Internet Explorer OLE Pre-IE11 - Automation Array Remote Code Execution / Powershell VirtualAlloc (MS14-064), PoC
-                             # http://www.exploit-db.com/exploits/35229/, Internet Explorer <= 11 - OLE Automation Array Remote Code Execution (#1), PoC
-                             # http://www.exploit-db.com/exploits/35230/, Internet Explorer < 11 - OLE Automation Array Remote Code Execution (MSF), MSF
-                             # http://www.exploit-db.com/exploits/35235/, MS14-064 Microsoft Windows OLE Package Manager Code Execution Through Python, MSF
-                             # http://www.exploit-db.com/exploits/35236/, MS14-064 Microsoft Windows OLE Package Manager Code Execution, MSF
-    ['MS14-062', ALERT.MSF], # CVE 2014-4971
-                             # http://www.exploit-db.com/exploits/34112/, Microsoft Windows XP SP3 MQAC.sys - Arbitrary Write Privilege Escalation, PoC
-                             # http://www.exploit-db.com/exploits/34982/, Microsoft Bluetooth Personal Area Networking (BthPan.sys) Privilege Escalation
-    ['MS14-060', ALERT.MSF], # CVE 2014-4114
-                             # http://www.exploit-db.com/exploits/35055/, Windows OLE - Remote Code Execution "Sandworm" Exploit (MS14-060), PoC
-                             # http://www.exploit-db.com/exploits/35020/, MS14-060 Microsoft Windows OLE Package Manager Code Execution, MSF
-    ['MS14-058', ALERT.MSF], # CVE 2014-4113
-                             # http://www.exploit-db.com/exploits/35101/, Windows TrackPopupMenu Win32k NULL Pointer Dereference, MSF
-    ['MS14-040', ALERT.EXP], # CVE 2014-1767
-                             # https://www.exploit-db.com/exploits/39525/, Microsoft Windows 7 x64 - afd.sys Privilege Escalation (MS14-040), PoC
-                             # https://www.exploit-db.com/exploits/39446/, Microsoft Windows - afd.sys Dangling Pointer Privilege Escalation (MS14-040), PoC
+
+    ['MS16-135', ALERT.EXP, [ # CVE-2016-7255
+    "https://www.exploit-db.com/exploits/40745/ -- Microsoft Windows Kernel - win32k Denial of Service (MS16-135)",
+    "https://www.exploit-db.com/exploits/41015/ -- Microsoft Windows Kernel - 'win32k.sys' 'NtSetWindowLongPtr' Privilege Escalation (MS16-135) (2)",
+    "https://github.com/tinysec/public/tree/master/CVE-2016-7255"]],
+
+    ['MS16-129', ALERT.EXP, [ # CVE 2016-7200, CVE-2016-7201
+    "https://www.exploit-db.com/exploits/40990/ -- Microsoft Edge (Windows 10) - 'chakra.dll' Info Leak / Type Confusion Remote Code Execution",
+    "https://github.com/theori-io/chakra-2016-11"]],
+
+    ['MS16-098', ALERT.EXP, [
+    "https://www.exploit-db.com/exploits/41020/ -- Microsoft Windows 8.1 (x64) - RGNOBJ Integer Overflow (MS16-098)"]],
+
+    ['MS16-075', ALERT.MSF, [
+    "https://github.com/foxglovesec/RottenPotato",
+	"https://github.com/Kevin-Robertson/Tater",
+	"https://bugs.chromium.org/p/project-zero/issues/detail?id=222 -- Windows: Local WebDAV NTLM Reflection Elevation of Privilege",
+    "https://foxglovesecurity.com/2016/01/16/hot-potato/ -- Hot Potato - Windows Privilege Escalation"]],
+
+    ['MS16-074', ALERT.EXP, [ # CVE 2016-3216
+     "https://www.exploit-db.com/exploits/39990/ -- Windows - gdi32.dll Multiple DIB-Related EMF Record Handlers Heap-Based Out-of-Bounds Reads/Memory Disclosure (MS16-074), PoC",
+     "https://www.exploit-db.com/exploits/39991/ -- Windows Kernel - ATMFD.DLL NamedEscape 0x250C Pool Corruption (MS16-074), PoC"]], # CVE 2016-3220
+
+    ['MS16-063', ALERT.EXP, [ # CVE 2016-0199
+     "https://www.exploit-db.com/exploits/39994/ -- Internet Explorer 11 - Garbage Collector Attribute Type Confusion (MS16-063), PoC"]],
+
+    ['MS16-042', ALERT.EXP, [ # CVE 2016-0122
+     "https://www.exploit-db.com/exploits/39694/ -- Microsoft Office Excel Out-of-Bounds Read Remote Code Execution (MS16-042), PoC"]],
+
+    ['MS16-059', ALERT.EXP, [ # CVE 2016-0185
+     "https://www.exploit-db.com/exploits/39805/ -- Microsoft Windows Media Center - .MCL File Processing Remote Code Execution (MS16-059), PoC"]],
+
+    ['MS16-056', ALERT.EXP, [ # CVE-2015-1730
+     "https://www.exploit-db.com/exploits/40881/ -- Microsoft Internet Explorer - jscript9 Java­Script­Stack­Walker Memory Corruption (MS15-056)",
+     "http://blog.skylined.nl/20161206001.html -- MSIE jscript9 Java­Script­Stack­Walker memory corruption"]],
+
+    ['MS16-032', ALERT.EXP, [ # CVE 2016-0099
+     "https://www.exploit-db.com/exploits/40107/ -- MS16-032 Secondary Logon Handle Privilege Escalation, MSF",
+     "https://www.exploit-db.com/exploits/39574/ -- Microsoft Windows 8.1/10 - Secondary Logon Standard Handles Missing Sanitization Privilege Escalation (MS16-032), PoC",
+     "https://www.exploit-db.com/exploits/39719/ -- Microsoft Windows 7-10 & Server 2008-2012 (x32/x64) - Local Privilege Escalation (MS16-032) (PowerShell), PoC",
+     "https://www.exploit-db.com/exploits/39809/ -- Microsoft Windows 7-10 & Server 2008-2012 (x32/x64) - Local Privilege Escalation (MS16-032) (C#)"]],
+
+    ['MS16-016', ALERT.MSF, [ # CVE 2016-0051
+     "https://www.exploit-db.com/exploits/40085/ -- MS16-016 mrxdav.sys WebDav Local Privilege Escalation, MSF",
+     "https://www.exploit-db.com/exploits/39788/ -- Microsoft Windows 7 - WebDAV Privilege Escalation Exploit (MS16-016) (2), PoC",
+     "https://www.exploit-db.com/exploits/39432/ -- Microsoft Windows 7 SP1 x86 - WebDAV Privilege Escalation (MS16-016) (1), PoC"]],
+
+    ['MS16-014', ALERT.EXP, [ # CVE 2016-0400
+     "Windows 7 SP1 x86 - Privilege Escalation (MS16-014), https://www.exploit-db.com/exploits/40039/, PoC"]],
+
+    ['MS16-007', ALERT.EXP, [ # CVE 2016-0015, CVE 2016-0016
+     "https://www.exploit-db.com/exploits/39232/ -- Microsoft Windows devenum.dll!DeviceMoniker::Load() - Heap Corruption Buffer Underflow (MS16-007), PoC",
+     "https://www.exploit-db.com/exploits/39233/ -- Microsoft Office / COM Object DLL Planting with WMALFXGFXDSP.dll (MS-16-007), PoC"]],
+
+    ['MS15-134', ALERT.EXP, [ # CVE 2015-6131
+     "https://www.exploit-db.com/exploits/38911/ -- Microsoft Windows Media Center Library Parsing RCE Vulnerability aka self-executing' MCL File, PoC",
+     "https://www.exploit-db.com/exploits/38912/ -- Microsoft Windows Media Center Link File Incorrectly Resolved Reference, PoC",
+     "https://www.exploit-db.com/exploits/38918/ -- Microsoft Office / COM Object - 'els.dll' DLL Planting (MS15-134)",
+     "https://code.google.com/p/google-security-research/issues/detail?id=514 -- Microsoft Office / COM Object DLL Planting with els.dll"]],
+
+    ['MS15-132', ALERT.EXP, [ # CVE 2015-6132, CVE 2015-6128
+     "https://www.exploit-db.com/exploits/38968/ -- Microsoft Office / COM Object DLL Planting with comsvcs.dll Delay Load of mqrt.dll (MS15-132), PoC",
+     "https://www.exploit-db.com/exploits/38918/ -- Microsoft Office / COM Object els.dll DLL Planting (MS15-134), PoC"]],
+
+    ['MS15-112', ALERT.EXP, [ # CVE 2015-6086
+     "https://www.exploit-db.com/exploits/39698/ -- Internet Explorer 9/10/11 - CDOMStringDataList::InitFromString Out-of-Bounds Read (MS15-112)"]],
+
+    ['MS15-111', ALERT.EXP, [ # CVE 2015-2553
+     "https://www.exploit-db.com/exploits/38474/ -- Windows 10 Sandboxed Mount Reparse Point Creation Mitigation Bypass (MS15-111), PoC"]],
+
+    ['MS15-102', ALERT.EXP, [ # CVE 2015-2524, CVE 2015-2525, CVE 2015-2528
+     "https://www.exploit-db.com/exploits/38202/ -- Windows CreateObjectTask SettingsSyncDiagnostics Privilege Escalation, PoC",
+     "https://www.exploit-db.com/exploits/38200/ -- Windows Task Scheduler DeleteExpiredTaskAfter File Deletion Privilege Escalation, PoC",
+     "https://www.exploit-db.com/exploits/38201/ -- Windows CreateObjectTask TileUserBroker Privilege Escalation, PoC"]],
+
+    ['MS15-100', ALERT.MSF, [ # CVE 2015-2509
+     "https://www.exploit-db.com/exploits/38195/ -- MS15-100 Microsoft Windows Media Center MCL Vulnerability, MSF",
+     "https://www.exploit-db.com/exploits/38151/ -- Windows Media Center - Command Execution (MS15-100), PoC"]],
+
+    ['MS15-097', ALERT.EXP, [ # CVE 2015-2508, CVE 2015-2527
+     "https://www.exploit-db.com/exploits/38198/ -- Windows 10 Build 10130 - User Mode Font Driver Thread Permissions Privilege Escalation, PoC",
+     "https://www.exploit-db.com/exploits/38199/ -- Windows NtUserGetClipboardAccessToken Token Leak, PoC"]],
+
+    ['MS15-078', ALERT.MSF, [ # CVE 2015-2426, CVE 2015-2433
+     "https://www.exploit-db.com/exploits/38222/ -- MS15-078 Microsoft Windows Font Driver Buffer Overflow"]],
+
+    ['MS15-052', ALERT.EXP, [ # CVE 2015-1674
+     "https://www.exploit-db.com/exploits/37052/ -- Windows - CNG.SYS Kernel Security Feature Bypass PoC (MS15-052), PoC"]],
+
+    ['MS15-051', ALERT.MSF, [ # CVE 2015-1701
+     "https://github.com/hfiref0x/CVE-2015-1701, Win32k Elevation of Privilege Vulnerability, PoC",
+     "https://www.exploit-db.com/exploits/37367/ -- Windows ClientCopyImage Win32k Exploit, MSF"]],
+
+    ['MS15-022', ALERT.EXP, [ # CVE 2015-0097
+     "https://www.exploit-db.com/exploits/37657/ -- Microsoft Word Local Machine Zone Remote Code Execution Vulnerability, PoC",
+     "https://github.com/offensive-security/exploit-database-bin-sploits/raw/master/sploits/37657.zip"]],
+
+    ['MS15-010', ALERT.EXP, [ # CVE 2015-0057
+     "https://www.exploit-db.com/exploits/39035/ -- Microsoft Windows 8.1 - win32k Local Privilege Escalation (MS15-010), PoC",
+     "https://www.exploit-db.com/exploits/37098/ -- Microsoft Windows - Local Privilege Escalation (MS15-010), PoC",
+     "https://www.exploit-db.com/exploits/39035/ -- Microsoft Windows win32k Local Privilege Escalation (MS15-010), PoC"]],
+
+    ['MS15-001', ALERT.EXP, [ # CVE 2015-0002
+     "http://www.exploit-db.com/exploits/35661/ -- Windows 8.1 (32/64 bit) - Privilege Escalation (ahcache.sys/NtApphelpCacheControl), PoC"]],
+
+    ['MS14-070', ALERT.EXP, [ # CVE 2014 4076
+     "http://www.exploit-db.com/exploits/35936/ -- Microsoft Windows Server 2003 SP2 - Privilege Escalation, PoC"]],
+
+    ['MS14-068', ALERT.EXP, [ # CVE 2014-6324
+     "http://www.exploit-db.com/exploits/35474/ -- Windows Kerberos - Elevation of Privilege (MS14-068), PoC"]],
+
+    ['MS14-064', ALERT.MSF, [ # CVE 2014-6332
+     "https://www.exploit-db.com/exploits/37800// -- Microsoft Windows HTA (HTML Application) - Remote Code Execution (MS14-064), PoC",
+     "http://www.exploit-db.com/exploits/35308/ -- Internet Explorer OLE Pre-IE11 - Automation Array Remote Code Execution / Powershell VirtualAlloc (MS14-064), PoC",
+     "http://www.exploit-db.com/exploits/35229/ -- Internet Explorer <= 11 - OLE Automation Array Remote Code Execution (#1), PoC",
+     "http://www.exploit-db.com/exploits/35230/ -- Internet Explorer < 11 - OLE Automation Array Remote Code Execution (MSF), MSF",
+     "http://www.exploit-db.com/exploits/35235/ -- MS14-064 Microsoft Windows OLE Package Manager Code Execution Through Python, MSF",
+     "http://www.exploit-db.com/exploits/35236/ -- MS14-064 Microsoft Windows OLE Package Manager Code Execution, MSF"]],
+
+    ['MS14-062', ALERT.MSF, [ # CVE 2014-4971
+     "http://www.exploit-db.com/exploits/34112/ -- Microsoft Windows XP SP3 MQAC.sys - Arbitrary Write Privilege Escalation, PoC",
+     "http://www.exploit-db.com/exploits/34982/ -- Microsoft Bluetooth Personal Area Networking (BthPan.sys) Privilege Escalation"]],
+
+    ['MS14-060', ALERT.MSF, [ # CVE 2014-4114
+     "http://www.exploit-db.com/exploits/35055/ -- Windows OLE - Remote Code Execution 'Sandworm' Exploit (MS14-060), PoC",
+     "http://www.exploit-db.com/exploits/35020/ -- MS14-060 Microsoft Windows OLE Package Manager Code Execution, MSF"]],
+
+    ['MS14-058', ALERT.MSF, [ # CVE 2014-4113
+     "http://www.exploit-db.com/exploits/35101/ -- Windows TrackPopupMenu Win32k NULL Pointer Dereference, MSF"]],
+
+    ['MS14-040', ALERT.EXP, [ # CVE 2014-1767
+     "https://www.exploit-db.com/exploits/39525/ -- Microsoft Windows 7 x64 - afd.sys Privilege Escalation (MS14-040), PoC",
+     "https://www.exploit-db.com/exploits/39446/ -- Microsoft Windows - afd.sys Dangling Pointer Privilege Escalation (MS14-040), PoC"]],
+
     ['MS14-035', ALERT.EXP],
-    ['MS14-029', ALERT.EXP], #http://www.exploit-db.com/exploits/34458/
-    ['MS14-026', ALERT.EXP], # CVE 2014-1806
-                             # http://www.exploit-db.com/exploits/35280/, .NET Remoting Services Remote Command Execution, PoC,
+    ['MS14-029', ALERT.EXP, [
+     "http://www.exploit-db.com/exploits/34458/"]],
+
+    ['MS14-026', ALERT.EXP, [ # CVE 2014-1806
+     "http://www.exploit-db.com/exploits/35280/, -- .NET Remoting Services Remote Command Execution, PoC"]],
+
     ['MS14-017', ALERT.MSF],
     ['MS14-012', ALERT.MSF],
     ['MS14-009', ALERT.MSF],
@@ -1344,9 +1415,10 @@ def getexploit(msid = 0):
     ['MS13-053', ALERT.MSF],
     ['MS13-009', ALERT.MSF],
     ['MS13-005', ALERT.MSF],
-    ['MS12-037', ALERT.EXP], # CVE 2012-1876
-                             # http://www.exploit-db.com/exploits/35273/, Internet Explorer 8 - Fixed Col Span ID Full ASLR, DEP & EMET 5., PoC
-                             # http://www.exploit-db.com/exploits/34815/, Internet Explorer 8 - Fixed Col Span ID Full ASLR, DEP & EMET 5.0 Bypass (MS12-037), PoC
+    ['MS12-037', ALERT.EXP, [ # CVE 2012-1876
+     "http://www.exploit-db.com/exploits/35273/ -- Internet Explorer 8 - Fixed Col Span ID Full ASLR, DEP & EMET 5., PoC",
+     "http://www.exploit-db.com/exploits/34815/ -- Internet Explorer 8 - Fixed Col Span ID Full ASLR, DEP & EMET 5.0 Bypass (MS12-037), PoC"]],
+
     ['MS12-022', ALERT.MSF],
     ['MS11-080', ALERT.MSF],
     ['MS11-011', ALERT.EXP],
@@ -1360,7 +1432,9 @@ def getexploit(msid = 0):
     ['MS09-067', ALERT.MSF],
     ['MS09-065', ALERT.MSF],
     ['MS09-053', ALERT.MSF],
-    ['MS09-050', ALERT.MSF],
+    ['MS09-050', ALERT.MSF, [
+    "https://www.rapid7.com/db/modules/exploit/windows/smb/ms09_050_smb2_negotiate_func_index -- MS09-050 Microsoft SRV2.SYS SMB Negotiate ProcessID Function Table Dereference"]],
+    
     ['MS09-050', ALERT.MSF],
     ['MS09-043', ALERT.MSF],
     ['MS09-020', ALERT.MSF],
@@ -1437,9 +1511,15 @@ def getexploit(msid = 0):
 
   for exploit in exploits:
     if msid == exploit[0]:
-      return exploit[1]
+      # need 3 values to unpack, in case there are resources
+      if len(exploit) == 2: 
+          exploit.append(None)
+          return exploit
+      
+      # otherwise there are 3 values
+      return exploit
   
-  return False
+  return [False,False,False]
 
 # the update function
 def update():

--- a/windows-exploit-suggester.py
+++ b/windows-exploit-suggester.py
@@ -340,7 +340,7 @@ from sys import exit
 # constants/globals
 MSSB_URL = 'http://www.microsoft.com/en-gb/download/confirmation.aspx?id=36982'
 BULLETIN_URL = 'http://download.microsoft.com/download/6/7/3/673E4349-1CA5-40B9-8879-095C72D5B49D/BulletinSearch.xlsx'
-VERSION = "3.2"
+VERSION = "3.3"
 
 # global parser
 parser = argparse.ArgumentParser(description="search microsoft security bulletins for exploits based upon the patch level of the machine by feeding in systeminfo command")


### PR DESCRIPTION
The osnamearray defined in getname() needs an update for server 2016 

```
def getname(ostext):

  if ostext == False:
    return False
      
  osname=False

  osnamearray=[["xp","XP"],
               ["2000","2000"],
               ["2003","2003"],
               ["vista","Vista"],
               ["2008","2008"],
               [" 7","7"],
               [" 8","8"],
               ["2012","2012"],
               ["2016","2016"],       <== Add
               ["8.1","8.1"],
               [" 10","10"]]
```